### PR TITLE
Updates to https://github.com/github/hub/pull/1145

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -279,11 +279,7 @@ func createPullRequestMessage(base, head, fullBase, fullHead string) (string, er
 	}
 
 	if tmplate := github.GetPullRequestTemplate(); tmplate != "" {
-		if defaultMsg != "" {
-			defaultMsg = defaultMsg + tmplate
-		} else {
-			defaultMsg = tmplate
-		}
+		defaultMsg = github.GeneratePRTemplate(defaultMsg)
 	}
 
 	cs := git.CommentChar()

--- a/fixtures/test_repo.go
+++ b/fixtures/test_repo.go
@@ -59,6 +59,31 @@ func (r *TestRepo) AddRemote(name, url, pushURL string) {
 	}
 }
 
+func (r *TestRepo) AddGithubTemplatesDir() {
+	github_dir := filepath.Join(r.dir, "test.git", ".github")
+	pr_template_path := filepath.Join(github_dir, "PULL_REQUEST_TEMPLATE.md")
+	issue_template_path := filepath.Join(github_dir, "ISSUE_TEMPLATE")
+
+	// Make `.github` dir in root of test repo
+	err := os.MkdirAll(filepath.Dir(issue_template_path), 0771)
+	if err != nil {
+		panic(err)
+	}
+
+	// Switch to the root of the project dir
+	err = os.Chdir(filepath.Join(r.dir, "test.git"))
+	if err != nil {
+		panic(err)
+	}
+
+	content := `Description
+-----------
+[Enter your pull request description here]
+`
+	ioutil.WriteFile(pr_template_path, []byte(content), os.ModePerm)
+	ioutil.WriteFile(issue_template_path, []byte(content), os.ModePerm)
+}
+
 func (r *TestRepo) clone(repo, dir string) error {
 	cmd := cmd.New("git").WithArgs("clone", repo, dir)
 	output, err := cmd.CombinedOutput()

--- a/github/template.go
+++ b/github/template.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	pullRequestTempalte = "PULL_REQUEST_TEMPLATE"
-	issueTempalte       = "ISSUE_TEMPLATE"
+	issueTemplate       = "ISSUE_TEMPLATE"
 	githubTemplateDir   = ".github"
 )
 

--- a/github/template.go
+++ b/github/template.go
@@ -24,7 +24,7 @@ func GetIssueTemplate() string {
 }
 
 func GeneratePRTemplate(defaultMsg string) string {
-	return "\n\n" + GetPullRequestTemplate()
+	return strings.Split(defaultMsg, "\n")[0] + "\n\n" + GetPullRequestTemplate()
 }
 
 func getGithubTemplate(pat string) (body string) {

--- a/github/template.go
+++ b/github/template.go
@@ -20,7 +20,11 @@ func GetPullRequestTemplate() string {
 }
 
 func GetIssueTemplate() string {
-	return getGithubTemplate(issueTempalte)
+	return getGithubTemplate(issueTemplate)
+}
+
+func GeneratePRTemplate(defaultMsg string) string {
+	return "\n\n" + GetPullRequestTemplate()
 }
 
 func getGithubTemplate(pat string) (body string) {

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -25,3 +25,48 @@ Description
 
 	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
 }
+
+// When a single line commit message is provided, the commit message should
+// encompass the first line, then a empty new line, then the template.
+func TestGeneratePRTemplate_SingleLineDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := "Add Pull Request Templates to Hub"
+	expectedOutput := `Add Pull Request Templates to Hub
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}
+
+// When a multi line commit message is provided, the first line of the commit
+// message should be the first line, then a empty new line, then the template.
+//
+// TODO (maybe):  Allow for templates to support auto filling the description
+// section with the rest of the commit message.
+func TestGeneratePRTemplate_MultiLineDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := `Add Pull Request Templates to Hub
+
+Allow repo maintainers to set a default template and allow developers to
+continue to use hub!
+`
+	expectedOutput := `Add Pull Request Templates to Hub
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}

--- a/github/template_test.go
+++ b/github/template_test.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/github/hub/fixtures"
+)
+
+// When no default message is provided, two blank lines should be added
+// (representing the pull request title), and the left should be template.
+func TestGeneratePRTemplate_NoDefaultMessage(t *testing.T) {
+	repo := fixtures.SetupTestRepo()
+	defer repo.TearDown()
+
+	repo.AddGithubTemplatesDir()
+
+	defaultMessage := ""
+	expectedOutput := `
+
+Description
+-----------
+[Enter your pull request description here]
+`
+
+	assert.Equal(t, expectedOutput, GeneratePRTemplate(defaultMessage))
+}


### PR DESCRIPTION
First off, I want to apologize for doing this without your consent first (went the whole "ask for forgiveness instead of asking for permission" route).  I personally wanted this for work purposes, and the work you had already done was a great base for me to get started with `go`, which was another reason I took this on myself.  Hopefully you don't see this as insult or rude, I was mearly trying to make this feature available to myself, with the added benefit of learning a new language.
## What's changed

As of right now, I have mostly just updated the case where you are adding the `defaultMsg` to the template string.  As I described [here](https://github.com/github/hub/pull/1145#issuecomment-208368551), there were a few flaws with your current implementation:

> - The PR template is meant to be just the description section of the PR, but when it isn't a single commit PR, the template is added to the editor as is, which makes the first line of the template the title instead of the start of the body.
> - With a single commit PR, the following happens:
>   - If it is just a single line commit, the commit messages is appended to the first line of the template instead of making it the first line and adding two new lines in between
>   - If it is a multi-line commit message, same problem, but it spans multiple lines until the last line of the commit message, where the last line of the commit message and the first line of the template are the same
> - Definite typo [here](https://github.com/ganmacs/hub/blob/ca209baff3637436462f5/github/template.go#L14) (issueTempalte) that I just noticed... breaks tests.

I have addressed these with the current commits, and I believe this should be functioning as expected (assuming this is the desired implemtation).

I am currently testing these changes using the following homebrew custom formula:

``` ruby
class Hub < Formula
  desc "Add GitHub support to git on the command-line"
  homepage "https://hub.github.com/"
  url 'https://github.com/NickLaMuro/hub.git', :using => :git, :branch => 'support-github-template'
  version '2'

  option "without-completions", "Disable bash/zsh completions"

  depends_on "go" => :build

  def install
    system "script/build", "-o", "hub"
    bin.install "hub"
    man1.install Dir["man/*"]

    if build.with? "completions"
      bash_completion.install "etc/hub.bash_completion.sh"
      zsh_completion.install "etc/hub.zsh_completion" => "_hub"
    end
  end

  test do
    HOMEBREW_REPOSITORY.cd do
      assert_equal "bin/brew", shell_output("#{bin}/hub ls-files -- bin").strip
    end
  end
end
```

To be used properly, you have to name the above file `hub.rb` or homebrew barfs.  Install using `brew install ./hub.rb`
## TODO
- [ ] Add more tests:  The tests that I have added have only really test my changes to your branch, and not the entirety of template.go.  A lot is covered there by those tests because I am hitting a top level method, but there should probably be some tests around finding detecting the different file permutations (with and without `.github` dir, with and without the `.md` extentions, etc.) that I haven't gottent to.
- [ ] Add cukes:  Some high-level integration tests would probably be better for describing the feature set that has been implemented, and a better way of defining the decisions that I made when handling the single commit PRs.  This was a bit daunting to start with though since I probably had to add some custom steps to do so, and was already dealing with learning the ropes of `golang`.
- [ ] Test this with a single commit PRs:  As stated above, I am using the changes in the PR via the custom homebrew recipe above, and even did it to open this PR (I added a PR template locally, but didn't commit it, so the entirety of this commit message was done via a template!).  That said, this is not a single commit PR, so I want to manually test the two cases for those in another commit in a seperate repository when I get the chance

I have skipped this for the time being to get a working copy of the code in place for others to use from source.  I will try and circle back and try to add these as possible.
## Legal Stuffs

I realize that to contribute to the base repo, I would need to agree to the [Github CLA](https://cla.github.com/).  I have no problem doing this, but I not sure if it will auto ask me when I am contributing to a PR of a PR.  Regardless, we can work this out with the maintainers as needed and I have no problem signing the agreement as well.
